### PR TITLE
fix: spawn npm with `shell: true` on Windows

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
@@ -55,10 +55,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
@@ -90,14 +90,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
@@ -128,7 +128,7 @@ jobs:
         npm publish
 
     - name: Create Github Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/src/lib/package-managers/npm/index.ts
+++ b/src/lib/package-managers/npm/index.ts
@@ -172,11 +172,15 @@ export class Npm extends PackageManager {
 		args: string[],
 		options: execa.Options<string> = {},
 	): Promise<CommandResult> {
+		const isWindows = process.platform === "win32";
 		const promise = execa("npm", args, {
 			...options,
 			cwd: this.cwd,
 			reject: false,
 			all: true,
+			// Windows needs shell to be true to execute npm
+			// https://github.com/nodejs/node/releases/tag/v18.20.2
+			shell: isWindows,
 		});
 
 		// Pipe command outputs if desired


### PR DESCRIPTION
fixes: #17 